### PR TITLE
Fix mobile longpress menu conflict

### DIFF
--- a/src/app/workspace/(TagTreeNav)/Folder.tsx
+++ b/src/app/workspace/(TagTreeNav)/Folder.tsx
@@ -44,6 +44,7 @@ interface FolderComponentProps {
     type: "tag" | "folder" | "page",
     data: TreeTag | TreeFolder | TreePage,
   ) => void;
+  isMobile: boolean;
 }
 
 export const FolderComponent: React.FC<FolderComponentProps> = ({
@@ -59,6 +60,7 @@ export const FolderComponent: React.FC<FolderComponentProps> = ({
   onCreateSubfolder,
   isLoading,
   onOpenDrawer,
+  isMobile,
 }) => {
   const isFolderExpanded = expandedFolders.has(folder.id);
   const longPressTimeout = useRef<NodeJS.Timeout>();
@@ -77,7 +79,68 @@ export const FolderComponent: React.FC<FolderComponentProps> = ({
   const handleTouchMove = () => {
     clearTimeout(longPressTimeout.current);
   };
-  return (
+  return isMobile ? (
+    <div onContextMenu={(e) => e.preventDefault()}>
+      <div
+        className="flex cursor-pointer items-center py-1 hover:bg-gray-50 dark:hover:bg-gray-700"
+        style={{ paddingLeft: `${(level + 1) * 16}px` }}
+        onClick={() => handleFolderToggle(folder.id)}
+        onTouchStart={handleTouchStart}
+        onTouchEnd={handleTouchEnd}
+        onTouchMove={handleTouchMove}
+      >
+        <button
+          className="mr-1 rounded focus:outline-none focus:ring-2 focus:ring-blue-300 dark:focus:ring-blue-600"
+          aria-expanded={isFolderExpanded}
+          aria-label={isFolderExpanded ? "Collapse folder" : "Expand folder"}
+        >
+          {isFolderExpanded ? (
+            <ChevronDown className="h-4 w-4 text-gray-400 dark:text-gray-500" />
+          ) : (
+            <ChevronRight className="h-4 w-4 text-gray-400 dark:text-gray-500" />
+          )}
+        </button>
+        <Folder className="mr-2 h-4 w-4 text-gray-400" />
+        <span className="text-sm text-gray-600 dark:text-gray-400">{folder.name}</span>
+      </div>
+
+      {isFolderExpanded && (
+        <div>
+          {folder.pages.map((page) => (
+            <PageComponent
+              key={page.id}
+              page={page}
+              level={level + 1}
+              currentPageId={currentPageId}
+              onMovePageClick={onMovePageClick}
+              handleItemClick={handleItemClick}
+              onOpenDrawer={onOpenDrawer}
+              isMobile={isMobile}
+            />
+          ))}
+
+          {folder.subFolders?.map((subfolder) => (
+            <FolderComponent
+              key={subfolder.id}
+              folder={subfolder}
+              level={level + 1}
+              parentTagId={parentTagId}
+              expandedFolders={expandedFolders}
+              handleFolderToggle={handleFolderToggle}
+              handleItemClick={handleItemClick}
+              currentPageId={currentPageId}
+              onMovePageClick={onMovePageClick}
+              onCreatePageInFolder={onCreatePageInFolder}
+              onCreateSubfolder={onCreateSubfolder}
+              isLoading={isLoading}
+              onOpenDrawer={onOpenDrawer}
+              isMobile={isMobile}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  ) : (
     <ContextMenu>
       <ContextMenuTrigger>
         <div>
@@ -119,6 +182,7 @@ export const FolderComponent: React.FC<FolderComponentProps> = ({
                   onMovePageClick={onMovePageClick}
                   handleItemClick={handleItemClick}
                   onOpenDrawer={onOpenDrawer}
+                  isMobile={isMobile}
                 />
               ))}
 
@@ -137,6 +201,7 @@ export const FolderComponent: React.FC<FolderComponentProps> = ({
                   onCreateSubfolder={onCreateSubfolder}
                   isLoading={isLoading}
                   onOpenDrawer={onOpenDrawer}
+                  isMobile={isMobile}
                 />
               ))}
             </div>

--- a/src/app/workspace/(TagTreeNav)/Page.tsx
+++ b/src/app/workspace/(TagTreeNav)/Page.tsx
@@ -34,6 +34,7 @@ interface PageComponentProps {
     type: "tag" | "folder" | "page",
     data: TreeTag | TreeFolder | TreePage,
   ) => void;
+  isMobile: boolean;
 }
 
 export const PageComponent: React.FC<PageComponentProps> = ({
@@ -43,6 +44,7 @@ export const PageComponent: React.FC<PageComponentProps> = ({
   onMovePageClick,
   handleItemClick,
   onOpenDrawer,
+  isMobile,
 }) => {
   const router = useRouter();
   const longPressTimeout = useRef<NodeJS.Timeout>();
@@ -77,7 +79,35 @@ export const PageComponent: React.FC<PageComponentProps> = ({
     handleItemClick(e, page.id, page.title || "");
   };
 
-  return (
+  return isMobile ? (
+    <div
+      className="touch-action-none select-none"
+      onTouchStart={handleTouchStart}
+      onTouchEnd={handleTouchEnd}
+      onTouchMove={handleTouchMove}
+      onContextMenu={(e) => e.preventDefault()}
+    >
+      <Link
+        href={`/workspace?pageId=${page.id}`}
+        onClick={handleClick}
+        onTouchStart={handleTouchStart}
+        onTouchEnd={handleTouchEnd}
+        className={`flex cursor-pointer items-center py-1 hover:bg-gray-50 dark:hover:bg-gray-700 ${
+          page.id === currentPageId ? "bg-gray-50/80 dark:bg-gray-700/30" : ""
+        } touch-action-none`}
+        style={{ paddingLeft: `${(level + 1) * 16}px` }}
+      >
+        {page.content_type === "canvas" ? (
+          <PanelTop className="mr-2 h-4 w-4 flex-shrink-0 text-gray-400" />
+        ) : (
+          <StickyNote className="mr-2 h-4 w-4 flex-shrink-0 text-gray-400" />
+        )}
+        <span className="min-w-0 truncate text-sm text-gray-600 dark:text-gray-400">
+          {page.title}
+        </span>
+      </Link>
+    </div>
+  ) : (
     <ContextMenu>
       <ContextMenuTrigger>
         <div

--- a/src/app/workspace/(TagTreeNav)/TagTreeNav.tsx
+++ b/src/app/workspace/(TagTreeNav)/TagTreeNav.tsx
@@ -433,19 +433,19 @@ const TreeNode: React.FC<{
             </DialogFooter>
           </form>
         </DialogContent>
-        <ContextMenu>
-          <ContextMenuTrigger>
+        {isMobile ? (
+          <div
+            className="touch-action-none select-none"
+            onTouchStart={handleTouchStart}
+            onTouchEnd={handleTouchEnd}
+            onTouchMove={handleTouchMove}
+            onContextMenu={(e) => e.preventDefault()}
+          >
             <div
-              className={isMobile ? "touch-action-none select-none" : ""}
-              onTouchStart={handleTouchStart}
-              onTouchEnd={handleTouchEnd}
-              onTouchMove={handleTouchMove}
+              className={`flex cursor-pointer items-center py-1 transition-colors duration-150 ease-in-out hover:bg-gray-50 dark:hover:bg-gray-700`}
+              style={{ paddingLeft: `${level * 16}px` }}
+              onClick={handleToggleExpand}
             >
-              <div
-                className={`flex cursor-pointer items-center py-1 transition-colors duration-150 ease-in-out hover:bg-gray-50 dark:hover:bg-gray-700`}
-                style={{ paddingLeft: `${level * 16}px` }}
-                onClick={handleToggleExpand}
-              >
                 {
                   <button
                     className="mr-1 rounded focus:outline-none focus:ring-2 focus:ring-blue-300 dark:focus:ring-blue-600"
@@ -467,59 +467,61 @@ const TreeNode: React.FC<{
               {/* Expanded content */}
               {isExpanded && (
                 <div className="ml-2">
-                  {hasPages &&
-                    node.pages.map((page) => (
-                      <PageComponent
-                        key={page.id}
-                        page={{
-                          id: page.id,
-                          title: page.title || "",
-                          folder_id: page.folder_id,
-                          primary_tag_id: page.primary_tag_id,
-                          content_type: page.content_type || "page",
-                        }}
-                        level={level}
-                        currentPageId={currentPageId ?? undefined}
-                        onMovePageClick={(pageId, title) => {
-                          setSelectedPage({
-                            id: pageId,
-                            title,
+                    {hasPages &&
+                      node.pages.map((page) => (
+                        <PageComponent
+                          key={page.id}
+                          page={{
+                            id: page.id,
+                            title: page.title || "",
                             folder_id: page.folder_id,
                             primary_tag_id: page.primary_tag_id,
-                          });
-                          setShowMoveDialog(true);
-                        }}
-                        handleItemClick={handleItemClick}
-                        onOpenDrawer={onOpenDrawer}
-                      />
-                    ))}
+                            content_type: page.content_type || "page",
+                          }}
+                          level={level}
+                          currentPageId={currentPageId ?? undefined}
+                          onMovePageClick={(pageId, title) => {
+                            setSelectedPage({
+                              id: pageId,
+                              title,
+                              folder_id: page.folder_id,
+                              primary_tag_id: page.primary_tag_id,
+                            });
+                            setShowMoveDialog(true);
+                          }}
+                          handleItemClick={handleItemClick}
+                          onOpenDrawer={onOpenDrawer}
+                          isMobile={isMobile}
+                        />
+                      ))}
                   {/* First render folders */}
                   {hasFolders &&
-                    node.folders.map((folder) => (
-                      <FolderComponent
-                        key={folder.id}
-                        folder={folder}
-                        level={level}
-                        parentTagId={node.id}
-                        expandedFolders={expandedFolders}
-                        handleFolderToggle={handleFolderToggle}
-                        handleItemClick={handleItemClick}
-                        currentPageId={currentPageId ?? undefined}
-                        onMovePageClick={(pageId, title) => {
-                          setSelectedPage({
-                            id: pageId,
-                            title,
-                            folder_id: folder.id,
-                            primary_tag_id: node.id,
-                          });
-                          setShowMoveDialog(true);
-                        }}
-                        onCreatePageInFolder={handleCreatePageInFolder}
-                        onCreateSubfolder={handleCreateSubfolder}
-                        isLoading={isLoading}
-                        onOpenDrawer={onOpenDrawer}
-                      />
-                    ))}
+                      node.folders.map((folder) => (
+                        <FolderComponent
+                          key={folder.id}
+                          folder={folder}
+                          level={level}
+                          parentTagId={node.id}
+                          expandedFolders={expandedFolders}
+                          handleFolderToggle={handleFolderToggle}
+                          handleItemClick={handleItemClick}
+                          currentPageId={currentPageId ?? undefined}
+                          onMovePageClick={(pageId, title) => {
+                            setSelectedPage({
+                              id: pageId,
+                              title,
+                              folder_id: folder.id,
+                              primary_tag_id: node.id,
+                            });
+                            setShowMoveDialog(true);
+                          }}
+                          onCreatePageInFolder={handleCreatePageInFolder}
+                          onCreateSubfolder={handleCreateSubfolder}
+                          isLoading={isLoading}
+                          onOpenDrawer={onOpenDrawer}
+                          isMobile={isMobile}
+                        />
+                      ))}
 
                   {/* Finally render child tags */}
                   {hasChildren &&
@@ -537,9 +539,117 @@ const TreeNode: React.FC<{
                 </div>
               )}
             </div>
-          </ContextMenuTrigger>
-          {/* Context menu for tags */}
-          <ContextMenuContent className="w-64">
+          </div>
+        ) : (
+          <ContextMenu>
+            <ContextMenuTrigger>
+              <div
+                className={isMobile ? "touch-action-none select-none" : ""}
+                onTouchStart={handleTouchStart}
+                onTouchEnd={handleTouchEnd}
+                onTouchMove={handleTouchMove}
+              >
+                <div
+                  className={`flex cursor-pointer items-center py-1 transition-colors duration-150 ease-in-out hover:bg-gray-50 dark:hover:bg-gray-700`}
+                  style={{ paddingLeft: `${level * 16}px` }}
+                  onClick={handleToggleExpand}
+                >
+                  {
+                    <button
+                      className="mr-1 rounded focus:outline-none focus:ring-2 focus:ring-blue-300 dark:focus:ring-blue-600"
+                      aria-expanded={isExpanded}
+                      aria-label={isExpanded ? "Collapse" : "Expand"}
+                    >
+                      {isExpanded ? (
+                        <ChevronDown className="h-4 w-4 text-gray-400 dark:text-gray-500" />
+                      ) : (
+                        <ChevronRight className="h-4 w-4 text-gray-400 dark:text-gray-500" />
+                      )}
+                    </button>
+                  }
+                  <span className="text-sm text-gray-700 dark:text-gray-300">
+                    {node.name}
+                  </span>
+                </div>
+
+                {/* Expanded content */}
+                {isExpanded && (
+                  <div className="ml-2">
+                    {hasPages &&
+                      node.pages.map((page) => (
+                        <PageComponent
+                          key={page.id}
+                          page={{
+                            id: page.id,
+                            title: page.title || "",
+                            folder_id: page.folder_id,
+                            primary_tag_id: page.primary_tag_id,
+                            content_type: page.content_type || "page",
+                          }}
+                          level={level}
+                          currentPageId={currentPageId ?? undefined}
+                          onMovePageClick={(pageId, title) => {
+                            setSelectedPage({
+                              id: pageId,
+                              title,
+                              folder_id: page.folder_id,
+                              primary_tag_id: page.primary_tag_id,
+                            });
+                            setShowMoveDialog(true);
+                          }}
+                          handleItemClick={handleItemClick}
+                          onOpenDrawer={onOpenDrawer}
+                          isMobile={isMobile}
+                        />
+                      ))}
+                    {/* First render folders */}
+                    {hasFolders &&
+                      node.folders.map((folder) => (
+                        <FolderComponent
+                          key={folder.id}
+                          folder={folder}
+                          level={level}
+                          parentTagId={node.id}
+                          expandedFolders={expandedFolders}
+                          handleFolderToggle={handleFolderToggle}
+                          handleItemClick={handleItemClick}
+                          currentPageId={currentPageId ?? undefined}
+                          onMovePageClick={(pageId, title) => {
+                            setSelectedPage({
+                              id: pageId,
+                              title,
+                              folder_id: folder.id,
+                              primary_tag_id: node.id,
+                            });
+                            setShowMoveDialog(true);
+                          }}
+                          onCreatePageInFolder={handleCreatePageInFolder}
+                          onCreateSubfolder={handleCreateSubfolder}
+                          isLoading={isLoading}
+                          onOpenDrawer={onOpenDrawer}
+                          isMobile={isMobile}
+                        />
+                      ))}
+
+                    {/* Finally render child tags */}
+                    {hasChildren &&
+                      node.children.map((child) => (
+                        <TreeNode
+                          key={child.id}
+                          node={child}
+                          level={level + 1}
+                          allTags={allTags}
+                          userId={userId}
+                          onOpenDrawer={onOpenDrawer}
+                          isMobile={isMobile}
+                        />
+                      ))}
+                  </div>
+                )}
+              </div>
+            </ContextMenuTrigger>
+            {/* Context menu for tags */}
+            <ContextMenuContent className="w-64">
             <ContextMenuItem
               onSelect={() => handleCreatePage("page")}
               disabled={isLoading}


### PR DESCRIPTION
## Summary
- avoid context menu on mobile by preventing it on touch
- add `isMobile` prop to page and folder tree nodes
- disable context menu in mobile mode

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685891bdb6088325aaff0587275e83bf